### PR TITLE
fix: Update dependabot config to format commit messages correctly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: weekly
-  - package-ecosystem: npm
-    directory: /
+      interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "build"
+      include: "scope"
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "build"
+      include: "scope"
+


### PR DESCRIPTION
Dependabot opens PRs for us and updates libraries, and that's great! But it doesn't format its commit messages the way release-please wants them, which doesn't create new package revs -- that's bad!

Stolen from here: https://rathbun.dev/posts/semantic-release-dependabot/